### PR TITLE
Remove port 4001 Dependency in etcdupdate.sh

### DIFF
--- a/gluster-configs/etcdupdate.sh
+++ b/gluster-configs/etcdupdate.sh
@@ -65,7 +65,7 @@ while getopts ":p:hf:d:" opt; do
       exit 0
       ;;
     p )
-      PEER_STRING="--peers ${OPTARG}:4001"
+      PEER_STRING="--peers ${OPTARG}"
       echo "Using etcd peer IP of ${OPTARG}"
       ;;
     \?)


### PR DESCRIPTION
Fedora 21 installs etcd pre-configured to run on port 2379. The current script expects it to be port 4001. We should allow the user to use a port of their choice. This PR removes the hardcoded 4001 port. This requires that the -p parameter now requires the port as follows:

./etcdupdate.sh -p 192.168.58.20:2379 -d .
